### PR TITLE
Feat : 스크롤해도 헤더 보이게 구현

### DIFF
--- a/src/components/layout/profileCardheader.tsx
+++ b/src/components/layout/profileCardheader.tsx
@@ -5,7 +5,7 @@ const ProfileCardHeader = () => {
   const {coin} = useProfileCardStore();
 
   return (
-    <header className="max-w-[430px] mx-auto h-[60px] bg-[#252525] z-50 flex justify-between items-center px-4">
+    <header className="fixed top-0 w-full max-w-[430px] mx-auto h-[60px] bg-[#252525] z-50 flex justify-between items-center px-4">
       <div>
         로고
       </div>

--- a/src/pages/matching/index.tsx
+++ b/src/pages/matching/index.tsx
@@ -60,7 +60,7 @@ const MatchingPage: React.FC = () => {
   const Details = `flex flex-col ml-[6%]`;
   
   return (
-    <Layout backgroundColor={'#252525'}>
+    <Layout backgroundColor={'#252525'} display='header'>
     <ProfileCardHeader />
     <div className={Style}>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#50 

## 📝작업 내용

헤더를 고정시켜 스크롤해도 헤더가 보이도록 했다.

### 스크린샷 (선택)
![image](https://github.com/CUK-CRUSH/Matching_Front/assets/91381230/770457b9-8d44-4aa9-9dbf-895d72790b4d)

## 💬리뷰 요구사항(선택)
